### PR TITLE
add webmanifest.json.share_target to "share" from other app to r4

### DIFF
--- a/webmanifest.json
+++ b/webmanifest.json
@@ -17,6 +17,15 @@
       "src": "/favicon.png",
       "sizes": "512x512",
       "type": "image/png"
+    },
+  ],
+  "share_target": {
+    "action": "/add",
+    "method": "GET",
+    "params": {
+      "url": "url",
+      "title": "title",
+      "text": "description"
     }
-  ]
+  }
 }


### PR DESCRIPTION
use https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/share_target

to reference the radio4000.com web app as share target for other app to share link to r4